### PR TITLE
Fix license information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "type": "magento2-module",
   "license": [
-    "OSL-3"
+    "MIT"
   ],
   "autoload": {
     "files": [


### PR DESCRIPTION
When trying to add this to packagist, I got the following error:

```
Invalid package information: 
License ["OSL-3"] is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```