### PR TITLE
Include support for banner/ajax/load controller (enterprise specific)

### DIFF
--- a/src/Plugin/BannerAjaxLoadControllerPlugin.php
+++ b/src/Plugin/BannerAjaxLoadControllerPlugin.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\SessionUnblocker\Plugin;
+
+use Magento\Framework\Session\Generic as GenericSession;
+use Magento\Framework\Session\SessionManagerInterface;
+
+/**
+ * We are writing this plugin to make sure sessions are all loaded
+ * Magento\Banner\Controller\Ajax\Load
+ *
+ * Right after initiating all the needed Sessions we close the session,
+ * since we're only reading from the session when requesting banners.
+ */
+class BannerAjaxLoadControllerPlugin
+{
+    /**
+     * @param GenericSession $genericSession
+     * @param SessionManagerInterface[] $additionalSessions
+     *
+     * Disabling 3 PHPCS rules because:
+     * 1 - We are well aware that we normally shouldn't call Sessions without
+     *     proxy, but in this case, we actually want the sessions to be
+     *     initiated directly.
+     * 2 - Also, we don't actually use the Sessions
+     * 3 - Lastly, we normally should not execute operations in a constructor
+     *
+     * phpcs:disable MEQP2.Classes.MutableObjects.MutableObjects
+     * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
+     * phpcs:disable MEQP2.Classes.ConstructorOperations.CustomOperationsFound
+     */
+    public function __construct(
+        GenericSession $genericSession,
+        array $additionalSessions = []
+    ) {
+        /**
+         * This is earliest moment where we can close the session,
+         * after we initialised all sessions we think will be needed
+         *
+         * Should there ever be an additional Session-type that's needed,
+         * nothing breaks, but the new session-type will open a new session
+         * and therefore block other requests
+         */
+        $genericSession->writeClose();
+    }
+
+    //phpcs:ignore MEQP2.Classes.PublicNonInterfaceMethods.PublicMethodFound
+    public function beforeExecute()
+    {
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -18,4 +18,16 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Banner\Controller\Ajax\Load">
+        <plugin name="integernet_session_unblocker" type="IntegerNet\SessionUnblocker\Plugin\BannerAjaxLoadControllerPlugin" />
+    </type>
+
+    <type name="IntegerNet\SessionUnblocker\Plugin\BannerAjaxLoadControllerPlugin">
+        <arguments>
+            <argument name="additionalSessions" xsi:type="array">
+                <item name="messageSession" xsi:type="object">Magento\Framework\Message\Session</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/tests/Integration/AbstractSessionTest.php
+++ b/tests/Integration/AbstractSessionTest.php
@@ -5,9 +5,11 @@ namespace IntegerNet\SessionUnblocker\Test\Integration;
 
 use IntegerNet\SessionUnblocker\Plugin\SessionStoragePlugin;
 use IntegerNet\SessionUnblocker\MethodLog;
-use IntegerNet\SessionUnblocker\Test\Util\SectionLoadActionSpy;
+use IntegerNet\SessionUnblocker\Test\Util\BannerAjaxLoadActionSpy;
+use IntegerNet\SessionUnblocker\Test\Util\CustomerSectionLoadActionSpy;
 use IntegerNet\SessionUnblocker\Test\Util\SessionSpy;
-use Magento\Customer\Controller\Section\Load as LoadAction;
+use Magento\Banner\Controller\Ajax\Load as BannerAjaxLoadAction;
+use Magento\Customer\Controller\Section\Load as CustomerSectionLoadAction;
 use Magento\Framework\Session\Generic as GenericSession;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
@@ -78,8 +80,9 @@ abstract class AbstractSessionTest extends AbstractController
         $this->objectManager->configure(
             [
                 'preferences'               => [
-                    LoadAction::class     => SectionLoadActionSpy::class,
-                    GenericSession::class => SessionSpy::class,
+                    BannerAjaxLoadAction::class      => BannerAjaxLoadActionSpy::class,
+                    CustomerSectionLoadAction::class => CustomerSectionLoadActionSpy::class,
+                    GenericSession::class            => SessionSpy::class,
                 ],
                 SessionStoragePlugin::class => [
                     'arguments' => ['doLogMethods' => true]

--- a/tests/Integration/BannerAjaxLoadControllerTest.php
+++ b/tests/Integration/BannerAjaxLoadControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\SessionUnblocker\Test\Integration;
+
+class BannerAjaxLoadControllerTest extends AbstractSessionTest
+{
+    public function testBannerAjaxLoad()
+    {
+        $this->when_dispatched('banner/ajax/load');
+        $this->then_sessions_have_been_started_and_closed_before_action();
+    }
+
+    public function testBannerAjaxLoadNoWrites()
+    {
+        $this->given_session_already_exists();
+        $this->when_dispatched('banner/ajax/load');
+        $this->then_sessions_have_not_been_modified_after_write();
+    }
+}

--- a/tests/Util/BannerAjaxLoadActionSpy.php
+++ b/tests/Util/BannerAjaxLoadActionSpy.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\SessionUnblocker\Test\Util;
+
+use IntegerNet\SessionUnblocker\MethodLog;
+use Magento\Banner\Controller\Ajax\Load;
+
+class BannerAjaxLoadActionSpy extends Load
+{
+    public function execute()
+    {
+        MethodLog::instance()->logControllerAction(parent::class, __FUNCTION__);
+        return parent::execute();
+    }
+
+}

--- a/tests/Util/CustomerSectionLoadActionSpy.php
+++ b/tests/Util/CustomerSectionLoadActionSpy.php
@@ -6,7 +6,7 @@ namespace IntegerNet\SessionUnblocker\Test\Util;
 use IntegerNet\SessionUnblocker\MethodLog;
 use Magento\Customer\Controller\Section\Load;
 
-class SectionLoadActionSpy extends Load
+class CustomerSectionLoadActionSpy extends Load
 {
     public function execute()
     {


### PR DESCRIPTION
Have a Magento Commerce 2.2 site which I just rolled out a modified version of this extension on a short while ago. Enterprise has a `banner/ajax/load` call which similarly reads from session, but never writes, so the changes here are adding support for that.

On my local test site with a `sleep(5)` added to exaggerate requests to both `banner/ajax/load` and `customer/section/load` for easily testing the lock release I get the following results:

**Before installation** (click to expand image):
![Screen-Shot-2019-11-13-13-01-48_48-before-with-sleep-5-B1Vq1J0EZFTpCojYcK88RlHagAqOu9VdXJWkFZjfJz4RyXMYlmZ6BKrklv5l1u8y8d6U4d3YwtqvmnTXX2MQv08cRbZn7ox82Moe](https://user-images.githubusercontent.com/658281/68861209-b3df7b80-06b0-11ea-9077-9c385b2f5599.jpg)

**After modified module is installed** (click to expand image):
![Screen-Shot-2019-11-13-13-01-48_48-after-with-sleep-5-3rOb84oBWaNDrq4mKbw4zvhTMbTvdImdzs06gME6diSZZJGV9xImJ8padUMAfJOuPQNdsg2fRogWpeqzMGqMWJYioN1d2HKkaAFS](https://user-images.githubusercontent.com/658281/68861290-e12c2980-06b0-11ea-905a-a3237069ff6b.jpg)

For now, I have this installed on the site by adding the following into the `composer.json` file to pull the modified module:

```
{
    "require": {
        "integer-net/magento2-session-unblocker": "dev-magento-enterprise-support as v0.1.4"
    },
    "minimum-stability": "stable",
    "repositories": {
        "magento2-session-unblocker": {
            "type": "vcs",
            "url": "https://github.com/davidalger/magento2-session-unblocker"
        }
    }
}
```

Given these changes introduce a hard dependency on the Commerce/Enterprise only `Magento\Banner\Controller\Ajax\Load` class in `tests/Integration/AbstractSessionTest.php`, the integration tests will fail if they are run from an open-source code base. DI rules targeting non-existent classes are merely ignored, so the module will install and run no problem on open-source however (verified this on a vanilla 2.3.3 OS with sample data).

I'm opening this PR both to share the work that I've done, but also ask for ideas on path forward to supporting controllers that do not exist in open-source. Have you guys thought about this yet and what might you suggest to support both open-source and enterprise?

One thought I had is perhaps splitting it to a separate module dependent on this one, keeping them nice and clean but that has the downside of multiple modules to maintain. Alternatively, the tests could be setup so only the open-source tests are run perhaps by using a different phpunit.xml file for enterprise and opensource integration testing where the enterprise one included additional tests, and then splitting `AbstractSessionTest::setUpSpies` out of the abstract to avoid hard dependencies on irrelevant controller classes.

Thoughts?